### PR TITLE
Ensure clearing of plotters layout

### DIFF
--- a/track.cpp
+++ b/track.cpp
@@ -18,6 +18,11 @@ Track::Track(QWidget *parent) : QWidget(parent)
     this->setFixedHeight(TrackHeight);
 }
 
+Track::~Track()
+{
+    delete plotter_;
+}
+
 void Track::setPlotter(TrackPlotter *plotter)
 {
    if(plotter_ != plotter)

--- a/track.h
+++ b/track.h
@@ -15,6 +15,7 @@ class Track : public QWidget
 public:
 
     explicit Track(QWidget *parent = nullptr);
+    ~Track();
 
     static const int TrackHeight = 120;
     static const int TrackHeaderWidth = 140;

--- a/trackview.cpp
+++ b/trackview.cpp
@@ -87,13 +87,24 @@ void TrackView::plot(sow::Dataset *dataset)
 void TrackView::clear()
 {
     QLayoutItem* child;
+    // Delete all tracks
+    while (tracksLayout_->count() != 0)
+    {
+        child = tracksLayout_->takeAt(0);
+        QWidget* widget = child->widget();
+        if(widget != nullptr)
+        {
+            delete widget;
+        }
+        delete child;
+    }
+
+    // Tracks will delete their plotters,
+    // but make sure any spacers etc. are
+    // deleted from plotsLayout
     while (plotsLayout_->count() != 0)
     {
         child = plotsLayout_->takeAt(0);
-        if(child->widget() != 0)
-        {
-            delete child->widget();
-        }
         delete child;
     }
 }


### PR DESCRIPTION
Tracks will delete plotters during destruction, but also need to loop through and clear any other layout items in the plotters layout.