### PR TITLE
Dev accessible widgets

### DIFF
--- a/sonification-workstation/SonificationWorkstation/AM.qml
+++ b/sonification-workstation/SonificationWorkstation/AM.qml
@@ -12,6 +12,10 @@ SynthItem {
     type: ENUMS.AMOD
     output: ENUMS.AM
 
+    Accessible.role: Accessible.focusable
+    Accessible.name: "Amplitude modulator. Modulates the amplitude of a signal."
+    Accessible.description: ""
+
     Component.onCompleted: {
         create()
     }

--- a/sonification-workstation/SonificationWorkstation/AUD.qml
+++ b/sonification-workstation/SonificationWorkstation/AUD.qml
@@ -12,6 +12,10 @@ SynthItem {
     type: ENUMS.AUDIFIER
     output: ENUMS.AUDIO
 
+    Accessible.role: Accessible.focusable
+    Accessible.name: "Oddifyer. Converts data values directly into amplitudes for audification."
+    Accessible.description: ""
+
     Component.onCompleted: {
         create()
     }

--- a/sonification-workstation/SonificationWorkstation/ENV.qml
+++ b/sonification-workstation/SonificationWorkstation/ENV.qml
@@ -12,6 +12,10 @@ SynthItem {
     type: ENUMS.ENVELOPE
     output: ENUMS.AUDIO
 
+    Accessible.role: Accessible.focusable
+    Accessible.name: "Envelope.  Applies simple attack decay envelope and outputs result."
+    Accessible.description: ""
+
     Component.onCompleted: {
         create()
     }

--- a/sonification-workstation/SonificationWorkstation/EQ.qml
+++ b/sonification-workstation/SonificationWorkstation/EQ.qml
@@ -12,6 +12,10 @@ SynthItem {
     type: ENUMS.EQUALIZER
     output: ENUMS.AUDIO
 
+    Accessible.role: Accessible.focusable
+    Accessible.name: "Equalizer. Provides a bye-quad audio filter."
+    Accessible.description: ""
+
     Component.onCompleted: {
         create()
     }

--- a/sonification-workstation/SonificationWorkstation/EditorScaler.qml
+++ b/sonification-workstation/SonificationWorkstation/EditorScaler.qml
@@ -36,6 +36,8 @@ ColumnLayout {
             implicitHeight: Style.editorRowHeight
             implicitWidth: implicitHeight
 
+            Accessible.ignored: true
+
             indicator: Rectangle {
 
                 implicitHeight: Style.editorRowHeight
@@ -61,6 +63,7 @@ ColumnLayout {
 
         EditorDoubleSpinBox {
             id: lowSpinBox
+            Accessible.ignored: true
         }
     }
     RowLayout {
@@ -71,6 +74,7 @@ ColumnLayout {
 
         EditorDoubleSpinBox {
             id: highSpinBox
+            Accessible.ignored: true
         }
     }
     RowLayout {
@@ -81,6 +85,7 @@ ColumnLayout {
 
         EditorDoubleSpinBox {
             id: expSpinBox
+            Accessible.ignored: true
             from: 100
             to: 6400
 //            stepSize: 10

--- a/sonification-workstation/SonificationWorkstation/FM.qml
+++ b/sonification-workstation/SonificationWorkstation/FM.qml
@@ -12,6 +12,10 @@ SynthItem {
     type: ENUMS.FMOD
     output: ENUMS.FM
 
+    Accessible.role: Accessible.focusable
+    Accessible.name: "F M. Modulates the frequency of an oscillator or pan object."
+    Accessible.description: ""
+
     Component.onCompleted: {
         create()
     }

--- a/sonification-workstation/SonificationWorkstation/NSE.qml
+++ b/sonification-workstation/SonificationWorkstation/NSE.qml
@@ -12,6 +12,10 @@ SynthItem {
     type: ENUMS.NOISE_GEN
     output: ENUMS.AUDIO
 
+    Accessible.role: Accessible.focusable
+    Accessible.name: "Noise. Generates white, pink, or brown noise."
+    Accessible.description: ""
+
     Component.onCompleted: {
         create()
     }

--- a/sonification-workstation/SonificationWorkstation/OSC.qml
+++ b/sonification-workstation/SonificationWorkstation/OSC.qml
@@ -12,6 +12,10 @@ SynthItem {
     type: ENUMS.OSCILLATOR
     output: ENUMS.AUDIO
 
+    Accessible.role: Accessible.ignored
+    Accessible.name: "Oscillator. Generates a sine wave."
+    Accessible.description: ""
+
     Component.onCompleted: {
         create()
     }

--- a/sonification-workstation/SonificationWorkstation/OUT.qml
+++ b/sonification-workstation/SonificationWorkstation/OUT.qml
@@ -9,6 +9,10 @@ SynthItem {
     type: ENUMS.TRANSPORT
     implementation: transport
 
+    Accessible.role: Accessible.focusable
+    Accessible.name: "Output. Connected signals are sent to the sound card."
+    Accessible.description: ""
+
     Component.onCompleted: {
         create()
     }

--- a/sonification-workstation/SonificationWorkstation/PAN.qml
+++ b/sonification-workstation/SonificationWorkstation/PAN.qml
@@ -12,6 +12,10 @@ SynthItem {
     type: ENUMS.PANNER
     output: ENUMS.AUDIO
 
+    Accessible.role: Accessible.focusable
+    Accessible.name: "Pan. Pans a signal in stereo."
+    Accessible.description: ""
+
     Component.onCompleted: {
         create()
     }

--- a/sonification-workstation/SonificationWorkstation/SonificationWorkstation.pro
+++ b/sonification-workstation/SonificationWorkstation/SonificationWorkstation.pro
@@ -9,6 +9,8 @@ TARGET = "Sonification Workstation"
 
 CONFIG += c++17
 
+QTPLUGIN += qtaccessiblewidgets
+
 # Application icons
 win32: RC_ICONS = sow.ico
 macx: ICON = sow.icns

--- a/sonification-workstation/SonificationWorkstation/VOL.qml
+++ b/sonification-workstation/SonificationWorkstation/VOL.qml
@@ -12,6 +12,10 @@ SynthItem {
     type: ENUMS.VOLUME
     output: ENUMS.AUDIO
 
+    Accessible.role: Accessible.focusable
+    Accessible.name: "Volume. Controls the amplitude of a signal."
+    Accessible.description: ""
+
     Component.onCompleted: {
         create()
     }

--- a/sonification-workstation/SonificationWorkstation/main.cpp
+++ b/sonification-workstation/SonificationWorkstation/main.cpp
@@ -14,6 +14,8 @@ using namespace sow;
 
 int main(int argc, char *argv[])
 {
+    // Import Qt Widgets accessiblity plugin.
+//    Q_IMPORT_PLUGIN(qtaccessiblewidgets)
 
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
@@ -40,12 +42,12 @@ int main(int argc, char *argv[])
     gam::Sync::master().spu(constants::SR);
 
     AudioIO audioIO(
-    128,        // block size
-    constants::SR,      // sample rate (Hz)
-    callback,   // user-defined callback
-    &uData,     // user data
-    2,          // input channels to open
-    2           // output
+    128,            // block size
+    constants::SR,  // sample rate (Hz)
+    callback,       // user-defined callback
+    &uData,         // user data
+    2,              // input channels to open
+    2               // output
     );
     audioIO.start();
 

--- a/sonification-workstation/SonificationWorkstation/transportwidget.cpp
+++ b/sonification-workstation/SonificationWorkstation/transportwidget.cpp
@@ -20,41 +20,41 @@ TransportWidget::TransportWidget(QWidget *parent) : QWidget(parent)
     // Transport controls.
     pauseButton_ = new QPushButton;
     pauseButton_->setObjectName("PauseButton");
-    pauseButton_->setAccessibleName("Play button.");
-    pauseButton_->setAccessibleDescription("Toggles playback on or off.");
+    pauseButton_->setAccessibleName("Play button, toggles playback on or off.");
+    pauseButton_->setAccessibleDescription("");
 
     recordButton_ = new QPushButton;
     recordButton_->setObjectName("RecordButton");
-    recordButton_->setAccessibleName("Record button.");
-    recordButton_->setAccessibleDescription("Start and stop recording to a wave file.");
+    recordButton_->setAccessibleName("Record button, start and stop recording to a wave file.");
+    recordButton_->setAccessibleDescription("");
 
     loopButton_ = new QPushButton;
     loopButton_->setObjectName("LoopButton");
-    loopButton_->setAccessibleName("Looping");
-    loopButton_->setAccessibleDescription("Toggles looping playback on or off");
+    loopButton_->setAccessibleName("Looping. Toggles looping playback on or off.");
+    loopButton_->setAccessibleDescription("");
 
     interpolateButton_ = new QPushButton;
     interpolateButton_->setObjectName("InterpolateButton");
-    interpolateButton_->setAccessibleName("Interpolation");
-    interpolateButton_->setAccessibleDescription("Toggles data interpolation on or off");
+    interpolateButton_->setAccessibleName("Interpolation, toggles data interpolation on or off.");
+    interpolateButton_->setAccessibleDescription("");
 
     muteButton_ = new QPushButton;
     muteButton_->setObjectName("MuteButton");
-    muteButton_->setAccessibleName("Mute");
-    muteButton_->setAccessibleDescription("Toggles mute on or off.");
+    muteButton_->setAccessibleName("Mute, toggles mute on or off.");
+    muteButton_->setAccessibleDescription("");
 
     speedBox_ = new QSpinBox;
     speedBox_->setObjectName("SpeedBox");
-    speedBox_->setAccessibleName("Speed spinbox");
-    speedBox_->setAccessibleDescription("Sets the playback speed in data points per second");
+    speedBox_->setAccessibleName("Speed spinbox, sets the playback speed in data points per second");
+    speedBox_->setAccessibleDescription("");
 
     QLabel* speedLabel = new QLabel;
     speedLabel->setObjectName("SpeedLabel");
 
     masterVolumeSlider_ = new MasterVolumeSlider(this);
     masterVolumeSlider_->setObjectName("MasterVolume");
-    masterVolumeSlider_->setAccessibleName("Main volume");
-    masterVolumeSlider_->setAccessibleDescription("Sets application master volume.  Range is zero to one hundred");
+    masterVolumeSlider_->setAccessibleName("Main volume, sets application master volume.  Range is zero to one hundred");
+    masterVolumeSlider_->setAccessibleDescription("");
 
     // Load icon files.
     playIcon_.addFile(":/images/play.svg");

--- a/sonification-workstation/SonificationWorkstation/transportwidget.cpp
+++ b/sonification-workstation/SonificationWorkstation/transportwidget.cpp
@@ -20,27 +20,41 @@ TransportWidget::TransportWidget(QWidget *parent) : QWidget(parent)
     // Transport controls.
     pauseButton_ = new QPushButton;
     pauseButton_->setObjectName("PauseButton");
-    pauseButton_->setFocusPolicy(Qt::NoFocus);
+    pauseButton_->setAccessibleName("Play button.");
+    pauseButton_->setAccessibleDescription("Toggles playback on or off.");
+
     recordButton_ = new QPushButton;
     recordButton_->setObjectName("RecordButton");
-    recordButton_->setFocusPolicy(Qt::NoFocus);
+    recordButton_->setAccessibleName("Record button.");
+    recordButton_->setAccessibleDescription("Start and stop recording to a wave file.");
+
     loopButton_ = new QPushButton;
     loopButton_->setObjectName("LoopButton");
-    loopButton_->setFocusPolicy(Qt::NoFocus);
+    loopButton_->setAccessibleName("Looping");
+    loopButton_->setAccessibleDescription("Toggles looping playback on or off");
+
     interpolateButton_ = new QPushButton;
     interpolateButton_->setObjectName("InterpolateButton");
-    interpolateButton_->setFocusPolicy(Qt::NoFocus);
+    interpolateButton_->setAccessibleName("Interpolation");
+    interpolateButton_->setAccessibleDescription("Toggles data interpolation on or off");
+
     muteButton_ = new QPushButton;
     muteButton_->setObjectName("MuteButton");
-    muteButton_->setFocusPolicy(Qt::NoFocus);
+    muteButton_->setAccessibleName("Mute");
+    muteButton_->setAccessibleDescription("Toggles mute on or off.");
+
     speedBox_ = new QSpinBox;
     speedBox_->setObjectName("SpeedBox");
-    speedBox_->setFocusPolicy(Qt::ClickFocus);
+    speedBox_->setAccessibleName("Speed spinbox");
+    speedBox_->setAccessibleDescription("Sets the playback speed in data points per second");
+
     QLabel* speedLabel = new QLabel;
     speedLabel->setObjectName("SpeedLabel");
+
     masterVolumeSlider_ = new MasterVolumeSlider(this);
     masterVolumeSlider_->setObjectName("MasterVolume");
-    masterVolumeSlider_->setFocusPolicy(Qt::NoFocus);
+    masterVolumeSlider_->setAccessibleName("Main volume");
+    masterVolumeSlider_->setAccessibleDescription("Sets application master volume.  Range is zero to one hundred");
 
     // Load icon files.
     playIcon_.addFile(":/images/play.svg");


### PR DESCRIPTION
Super basic accessible text added to widgets in the transport and QML synth objects.  Work still needs to be done to make interaction with spinboxes, checkboxes, patching, and more feasible through a screen reader.